### PR TITLE
Fixed path to vendor/autoload.php in bin scripts

### DIFF
--- a/bin/find-field
+++ b/bin/find-field
@@ -5,7 +5,9 @@
  * @author Denis Korenevskiy <denkoren@corp.badoo.com>
  */
 
-require __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';
+require realpath(dirname(__DIR__)) .
+    DIRECTORY_SEPARATOR . 'src' .
+    DIRECTORY_SEPARATOR . 'autoload.php';
 
 $Climate = new \League\CLImate\CLImate();
 

--- a/bin/generate
+++ b/bin/generate
@@ -4,8 +4,9 @@
  * @package REST
  * @author Denis Korenevskiy <denkoren@corp.badoo.com>
  */
-
-require __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';
+require realpath(dirname(__DIR__)) .
+    DIRECTORY_SEPARATOR . 'src' .
+    DIRECTORY_SEPARATOR . 'autoload.php';
 
 const EXIT_OK                       = 0;
 const EXIT_GENERATION_FAILED        = 1;

--- a/src/autoload.php
+++ b/src/autoload.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Wrapper for Composer's vendor/autoload.php.
+ *
+ * Particularly useful for the Composer vendor binaries.
+ * @link https://getcomposer.org/doc/articles/vendor-binaries.md
+ */
+return (function () {
+    $relative_path = DIRECTORY_SEPARATOR . 'vendor' .
+        DIRECTORY_SEPARATOR . 'autoload.php';
+
+    foreach ([1, 4] as $level) {
+        $absolute_path = dirname(__DIR__, $level) . $relative_path;
+
+        if (file_exists($absolute_path)) {
+            return require $absolute_path;
+        }
+    }
+
+    throw new \RuntimeException('Could not find Composer\'s autoload.php');
+})();


### PR DESCRIPTION
The vendor binaries under bin directory failed to load
`vendor/autoload.php` when called from a dependent project using the
symlinks generated by Composer. For example, the following commands:
```
cd /path/to/someproject
composer init
composer require 'badoo/jira-client'
./vendor/bin/find-field -h
```
failed with output similar to this:
```
PHP Warning:  require(/path/to/someproject/vendor/badoo/jira-client/bin/../vendor/autoload.php): failed to open stream: No such file or directory in /path/to/someproject/vendor/badoo/jira-client/bin/find-field on line 8
PHP Fatal error:  require(): Failed opening required '/path/to/someproject/vendor/badoo/jira-client/bin/../vendor/autoload.php' (include_path='.:/usr/share/php7:/usr/share/php') in /path/to/someproject/vendor/badoo/jira-client/bin/find-field on line 8
```