### PR TITLE
fix: Security Level id must be a string on issue creation

### DIFF
--- a/src/Issue/CreateRequest.php
+++ b/src/Issue/CreateRequest.php
@@ -424,7 +424,7 @@ class CreateRequest
      */
     public function setSecurityLevel(int $level_id) : CreateRequest
     {
-        return $this->setFieldValue('Security Level', ['id' => $level_id]);
+        return $this->setFieldValue('Security Level', ['id' => (string)$level_id]);
     }
 
     /**


### PR DESCRIPTION
We have error 

> Could not find valid 'id' or 'name' in security level object. 

when we trying to create issue this way
```php
$CreateRequest = new \Badoo\Jira\Issue\CreateRequest($project, $issue_type, $client);
$CreateRequest
    ->setPriority($priority)
    ->setSecurityLevel((int)$security_level)
    ->setSummary($summary)
    ->setDescription($description)
    ->addComponents($component);
```
But with this little change we have no errors 