### PR TITLE
fix: Fix not existed "name" property in User::fromStdClass

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         cacheResult="false"
+         colors="true"
+         verbose="true"
+>
+
+    <php>
+        <ini name="error_reporting" value="E_ALL"/>
+    </php>
+
+    <testsuites>
+
+        <testsuite name="All">
+            <directory>tests</directory>
+        </testsuite>
+
+    </testsuites>
+
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory>src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/User.php
+++ b/src/User.php
@@ -47,7 +47,7 @@ class User
         \Badoo\Jira\Issue $Issue = null,
         \Badoo\Jira\REST\Client $Jira = null
     ) : User {
-        $Instance = new static($UserInfo->name, $Jira);
+        $Instance = new static($UserInfo->name ?? $UserInfo->accountId, $Jira);
         $Instance->Issue = $Issue;
         $Instance->OriginalObject = $UserInfo;
 

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Badoo\Jira\UTests;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Base test case with common functionality.
+ */
+abstract class BaseTestCase extends TestCase
+{
+    /**
+     * Create new object of stdClass with defined properties.
+     *
+     * @param array<string, mixed> $properties Property-value map to setup object properties.
+     *
+     * @return \stdClass
+     */
+    protected static function createCustomObject(array $properties): \stdClass
+    {
+        $object = new \stdClass();
+        foreach ($properties as $name => $value) {
+            $object->{$name} = $value;
+        }
+
+        return $object;
+    }
+}

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Badoo\Jira\UTests;
+
+use Badoo\Jira\User;
+
+/**
+ * Tests for User class.
+ *
+ * @covers \Badoo\Jira\User
+ */
+class UserTest extends BaseTestCase
+{
+    /**
+     * Data provider for testCreateUserFromObject.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    public static function jiraUserDataProvider(): array
+    {
+        return [
+            'Jira Server' => [
+                'jiraUserData' => self::createCustomObject(
+                    [
+                        'name' => 'username',
+                    ]
+                ),
+                'expectedName' => 'username',
+            ],
+            'Jira Cloud after 29.04.2019' => [
+                'jiraUserData' => self::createCustomObject(
+                    [
+                        'accountId' => '5cf8e44f98b1560e85999040',
+                    ]
+                ),
+                'expectedName' => '5cf8e44f98b1560e85999040',
+            ],
+        ];
+    }
+
+    /**
+     * Test creating new User instance from Jira user data.
+     *
+     * @param \stdClass $jiraUserData Given Jira User object.
+     * @param string    $expectedName Expected user name.
+     *
+     * @throws \Throwable
+     *
+     * @dataProvider jiraUserDataProvider
+     */
+    public function testCreateUserFromObject(\stdClass $jiraUserData, string $expectedName): void
+    {
+        $user = User::fromStdClass($jiraUserData);
+
+        self::assertEquals($expectedName, $user->getName());
+    }
+}


### PR DESCRIPTION
User property "name" was removed from Jira Cloud API.
See https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/